### PR TITLE
Use Net::IP::Minimal instead of Net::IP

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -5,7 +5,7 @@ license           = Perl_5
 copyright_holder  = Rocco Caputo
 
 [Prereqs]
-Net::IP                   = 1.25
+Net::IP::Minimal          = 0.02
 POE                       = 1.311
 POE::Component::Resolver  = 0.913
 

--- a/lib/POE/Component/Client/Keepalive.pm
+++ b/lib/POE/Component/Client/Keepalive.pm
@@ -11,7 +11,7 @@ use POE;
 use POE::Wheel::SocketFactory;
 use POE::Component::Connection::Keepalive;
 use POE::Component::Resolver;
-use Net::IP qw(ip_is_ipv4);
+use Net::IP::Minimal qw(ip_is_ipv4);
 
 my $ssl_available;
 eval {


### PR DESCRIPTION
Net::IP consumes a fair chunk of memory, Net::DNS stopped using it
see https://rt.cpan.org/Public/Bug/Display.html?id=24525
