### PR TITLE
DRY in constructors

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,6 +7,7 @@ copyright_holder  = Rocco Caputo
 Net::IP::Minimal          = 0.02
 POE                       = 1.311
 POE::Component::Resolver  = 0.917
+Test::Fatal			      = 0
 
 [MetaResources]
 bugtracker        = http://rt.cpan.org/Public/Dist/Display.html?Name=POE-Component-Client-Keepalive

--- a/lib/POE/Component/Client/Keepalive.pm
+++ b/lib/POE/Component/Client/Keepalive.pm
@@ -146,14 +146,13 @@ sub new {
   # caller knows what they're doing.
   my $resolver = delete($args{resolver});
   if (!$resolver || !eval { $resolver->isa('POE::Component::Resolver') }) {
-    $resolver = POE::Component::Resolver->new;
+    $resolver = $default_resolver //= POE::Component::Resolver->new;
   }
   $constructor_args{SF_RESOLVER} = $resolver;
 
   # Anything unexpected is an error.
-  my @unknown = sort keys %args;
-  if (@unknown) {
-    croak "new() doesn't accept: @unknown";
+  if (keys %args) {
+    croak "new() doesn't accept: " . join(' ', sort keys %args);
   }
 
   # OK, unpack this hash into an arrayref of special stuff.

--- a/lib/POE/Component/Client/Keepalive.pm
+++ b/lib/POE/Component/Client/Keepalive.pm
@@ -163,6 +163,7 @@ sub new {
   }
   my $self = bless \@constructor_args, $class;
 
+  # Create a session and add it in.
   my $session = POE::Session->create(
     object_states => [
       $self => {
@@ -186,9 +187,6 @@ sub new {
       },
     ],
   );
-
-  ### FIXME: can this be moved into the constructor call, or does it have
-  ### side-effects?
   $self->[SF_ALIAS] = ref($self) . "::" . $session->ID();
 
   return $self;

--- a/lib/POE/Component/Client/Keepalive.pm
+++ b/lib/POE/Component/Client/Keepalive.pm
@@ -28,6 +28,7 @@ use constant {
 };
 
 # Manage connection request IDs.
+### FIXME: is this still being used? It's not being used in the constructor.
 
 my $current_id = 0;
 my %active_req_ids;
@@ -136,6 +137,7 @@ sub new {
     croak "new() doesn't accept: @unknown";
   }
 
+  ### FIXME: do we still need this?
   my $alias = "POE::Component::Client::Keepalive::" . ++$current_id;
 
   my $self = bless [

--- a/t/14_constructors.t
+++ b/t/14_constructors.t
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+
+# Test that arguments to various constructors are handled correctly.
+
+use warnings;
+use strict;
+use lib qw(./mylib ../mylib);
+use Test::More;
+
+sub POE::Kernel::ASSERT_DEFAULT () { 1 }
+
+use POE;
+
+my $test_class = 'POE::Component::Client::Keepalive';
+require_ok($test_class);
+
+default_arguments();
+
+done_testing();
+
+# The constructor behaves as we expect and fills in default arguments
+# if they're not supplied.
+
+sub default_arguments {
+
+  # We get something back.
+  my $client = POE::Component::Client::Keepalive->new;
+  isa_ok($client, $test_class, 'blank arguments get us an object');
+
+  # It has the default scalar values we expect.
+  my %default_scalar = (
+    SF_MAX_OPEN  => 4,
+    SF_MAX_OPEN  => 128,
+    SF_KEEPALIVE => 15,
+    SF_TIMEOUT   => 120,
+  );
+  for my $param (sort keys %default_scalar) {
+      is($client->[$client->$param], $default_scalar{$param},
+         "$param was set to default scalar value");
+  }
+
+  # Things we didn't specify are set to the appropriate empty values.
+  for my $hash_param (qw(SF_POOL SF_USED SF_WHEELS SF_USED_EACH SF_SOCKETS)) {
+      is_deeply($client->[$client->$hash_param], {},
+                "$hash_param was initialised to an empty hashref");
+  }
+  for my $undef_param (qw(SF_SHUTDOWN SF_REQ_INDEX)) {
+      is_deeply($client->[$client->$undef_param], undef,
+                "$undef_param was initialised to undef");
+  }
+  is_deeply($client->[$client->SF_QUEUE], [],
+            'SF_QUEUE was initialised to an empty arrayref');
+
+  # Resolver and alias have been set to something appropriate.
+  isa_ok($client->[$client->SF_RESOLVER], 'POE::Component::Resolver',
+         'A resolver was built for us');
+  like($client->[$client->SF_ALIAS], qr/^POE::Component::Client::Keepalive/,
+       'The alias looks sane');
+
+  # POE expects to run so stomp on warnings.
+  POE::Kernel->run;
+}

--- a/t/14_constructors.t
+++ b/t/14_constructors.t
@@ -5,7 +5,9 @@
 use warnings;
 use strict;
 use lib qw(./mylib ../mylib);
+
 use Test::More;
+use Test::Fatal;
 
 sub POE::Kernel::ASSERT_DEFAULT () { 1 }
 
@@ -14,9 +16,13 @@ use POE;
 my $test_class = 'POE::Component::Client::Keepalive';
 require_ok($test_class);
 
+# Run all of our tests.
 default_arguments();
+dodgy_arguments();
 
-done_testing();
+# POE expects to run so stomp on warnings.
+POE::Kernel->run;
+Test::More::done_testing();
 
 # The constructor behaves as we expect and fills in default arguments
 # if they're not supplied.
@@ -24,7 +30,7 @@ done_testing();
 sub default_arguments {
 
   # We get something back.
-  my $client = POE::Component::Client::Keepalive->new;
+  my $client = $test_class->new;
   isa_ok($client, $test_class, 'blank arguments get us an object');
 
   # It has the default scalar values we expect.
@@ -56,7 +62,9 @@ sub default_arguments {
          'A resolver was built for us');
   like($client->[$client->SF_ALIAS], qr/^POE::Component::Client::Keepalive/,
        'The alias looks sane');
+}
 
-  # POE expects to run so stomp on warnings.
-  POE::Kernel->run;
+sub dodgy_arguments {
+  ok(exception { $test_class->new(haxx0r => 'l33t yo') },
+    'Unexpected arguments get rebuffed');
 }

--- a/t/14_constructors.t
+++ b/t/14_constructors.t
@@ -101,6 +101,6 @@ sub override_defaults {
       $client->[$client->$constant],
       $non_defaults{$constructor_param},
       "Setting $constructor_param to something non-default took"
-      )
+    );
   }
 }

--- a/t/14_constructors.t
+++ b/t/14_constructors.t
@@ -82,7 +82,6 @@ sub _setup_param_aliases {
     keep_alive   => 'SF_KEEPALIVE',
     timeout      => 'SF_TIMEOUT',
   );
-
 }
 
 sub override_defaults {

--- a/t/14_constructors.t
+++ b/t/14_constructors.t
@@ -17,9 +17,6 @@ my $test_class = 'POE::Component::Client::Keepalive';
 require_ok($test_class);
 
 # Run all of our tests.
-my %param_alias;
-_setup_param_aliases();
-
 default_arguments();
 dodgy_arguments();
 override_defaults();
@@ -77,6 +74,7 @@ sub dodgy_arguments {
 
 # If we specify non-standard arguments, they override the defaults.
 
+my %param_alias;
 sub _setup_param_aliases {
   %param_alias = (
     max_per_host => 'SF_MAX_HOST',
@@ -88,6 +86,7 @@ sub _setup_param_aliases {
 }
 
 sub override_defaults {
+  _setup_param_aliases();
   my %non_defaults = (
     max_per_host => 5,
     max_open     => 127,


### PR DESCRIPTION
I asked to help out on random CPAN modules via the [CPAN PR challenge](http://blogs.perl.org/users/sawyer_x/2015/01/cpan-pull-request-challenge---resources-available.html), and I got assigned POE::Component::Client::Keepalive. I haven't ever done anything with POE, so this is me dumped in the deep end.

So while I explore a couple of outstanding issues (one of which I can reproduce partially but I don't understand why, because, well, never used POE), I thought I'd try something simpler. So I thought I'd look at the constructor of one of the main objects, which appears to violate DRY by making the most important information - the associated constant - a comment rather than something that code could do something about.

There are more things I could do on this subject but I thought I'd push a bunch of supposedly-reasonable code and ask first.

Does this look sane?
