### PR TITLE
dist.ini kwalitee amendments

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -7,10 +7,19 @@ copyright_holder  = Rocco Caputo
 Net::IP::Minimal          = 0.02
 POE                       = 1.311
 POE::Component::Resolver  = 0.917
+perl                      = 5.008
+
+[Prereqs / TestRequires]
+Pod::Coverage::TrustPod  = 0
+Test::Pod                = 1.41
+Test::Pod::Coverage      = 1.08
 
 [MetaResources]
 bugtracker        = http://rt.cpan.org/Public/Dist/Display.html?Name=POE-Component-Client-Keepalive
 repository        = https://github.com/rcaputo/poe-component-client-keepalive
+
+[MetaProvides::Package]
+[MetaJSON]
 
 [Repository]
 git_remote = gh


### PR DESCRIPTION
I've been assigned this dist as part of the [CPAN Pull Request Challenge](http://cpan-prc.org/). There were some items on CPANTS which this PR addresses, namely:
- Minimum version of perl specified
- Author test deps added
- Provides added

There are two points here you might want to consider before merging. One is that the author test deps obviously add to the total deps even though the average user will never need them. I can't immediately see a way around this in Dist::Zilla but it's not my usual deployment tool so perhaps I've missed something.

The other is that the minimum perl version required is 5.8.0 (the "use constant" line in POE/Component/Client/Keepalive.pm requires it), however the test t/000-report-versions.t mandates version 5.4.0 even though that very test actually requires 5.6.0 (for "use warnings"). As this particular test appears to be magically generated by dzil, I'm not aware of how to override the "require 5.004;" line in it.

Additionally the dzil hook for creating the META.json has also been added. I see no reason not to have this.

Please let me know if you would prefer any changes before merging this and also point me towards any other items in the dist which you think might benefit from some attention. 
